### PR TITLE
bullhead: add missing line continuation slash

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -335,7 +335,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # for perfd
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.min_freq_0=384000
+    ro.min_freq_0=384000 \
     ro.min_freq_4=384000
 
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This adds the perfd property that's missing in the build.prop. 

Change-Id: I54438caad981944d87a9bd3d9975230f104bce8a